### PR TITLE
Add I18n page.

### DIFF
--- a/resources/public/md/i18n.md
+++ b/resources/public/md/i18n.md
@@ -1,0 +1,18 @@
+## Internationalization
+
+Luminius template comes with [Tower](https://github.com/ptaoussanis/tower) dependency which
+provides you functionality for internationalization and
+translation. You are able to use a ring middleware
+
+```clojure
+(def app (-> all-routes
+             (middleware/app-handler)
+             (taoensso.tower.ring/make-wrap-i18n-middleware)))
+```
+or use `with-locale` macro to set up your locale explicitly:
+
+```clojure
+(with-locale :en (t :example/greeting "Steve")) => "Hello Steve, how are you?"
+```
+
+More information is available on the [Github](https://github.com/ptaoussanis/tower) page for the project.

--- a/src/luminus/docs.clj
+++ b/src/luminus/docs.clj
@@ -16,7 +16,8 @@
    ["security.md"         "Security"]
    ["database.md"         "Database access"]
    ["logging.md"          "Logging"]
-   ["deployment.md"       "Deployment"]])
+   ["deployment.md"       "Deployment"]
+   ["i18n.md"             "Internationalization"]])
 
 (defn doc-link [route selected? title]
   [:li (link-to {:class (if selected? "selected" "unselected")} route title)])


### PR DESCRIPTION
I've found that Tower is also dependency in Luminus as well as Timbre, but documention page for Internationalization/Localization doesn't exist. I've created simple page(similar to Logging page) to provide an idea how this library can be used. I think it's good to know what in the box. 
Any suggestions regarding naming or content are welcome.
Thanks.
