### PR TITLE
Add libraries page.

### DIFF
--- a/resources/public/md/useful_libraries.md
+++ b/resources/public/md/useful_libraries.md
@@ -1,0 +1,72 @@
+## Useful libraries
+
+Luminus provides to you some defaults like [Lib-noir](https://github.com/noir-clojure/lib-noir),
+[Hiccup](https://github.com/weavejester/hiccup) for HTML templating,
+[Timbre](https://github.com/ptaoussanis/timbre) for logging,
+[Tower](https://github.com/ptaoussanis/tower) for internationalization and others,
+but of course you able to use whatever libraries you want.
+Here we are going to provide a list of Clojure libraries which can be useful
+for web developent with Luminus.
+
+## Assets
+
+* [Dieter](https://github.com/edgecase/dieter) - Asset pipeline ring middleware
+
+## Async HTTP
+
+* [Aleph](https://github.com/ztellman/aleph) - Asynchronous communication
+* [http-kit](https://github.com/http-kit/http-kit) - High-performance event-driven HTTP client/server
+
+## Authentication
+
+* [Friend](https://github.com/cemerick/friend) - An extensible authentication and authorization library
+* [Sandbar](https://github.com/brentonashworth/sandbar) - A web application library with higher level abstractions for Compojure, Ring
+* [ring-basic-authentication](https://github.com/remvee/ring-basic-authentication) - Ring middleware to enforce basic authentication
+
+## Caching
+
+* [Spyglass](https://github.com/clojurewerkz/spyglass) - A Memcached client (also: Couchbase, Kestrel)
+* [core.cache](https://github.com/clojure/core.cache) - A caching library implementing various cache strategies
+
+## Database clients
+
+* [CongoMongo](https://github.com/aboekhoff/congomongo) - Wrapper for the mongo-db java api
+* [Monger](http://clojuremongodb.info/) - Monger, a client for MongoDB
+* [Clutch](https://github.com/clojure-clutch/clutch) - A library for Apache CouchDB
+* [Neocons](https://github.com/michaelklishin/neocons) - A feature rich idiomatic client for the Neo4J REST API
+* [Welle](http://clojureriak.info/) - An expressive client for Riak
+* [Cassaforte](https://github.com/clojurewerkz/cassaforte) - A young client for Apache Cassandra 1.2+
+* [Rotary](https://github.com/weavejester/rotary) - DynamoDB API
+* [Rummage](https://github.com/cemerick/rummage) - A client library for Amazon's SimpleDB (SDB)
+* [Carmine](https://github.com/ptaoussanis/carmine) - Clojure Redis client & message queue
+
+## Database Migrations
+
+* [Drift](https://github.com/macourtney/drift) - A migration library
+* [Lobos](http://budu.github.com/lobos/) - Lobos is a library to help you create and modify database schemas
+* [Migratus](https://github.com/pjstadig/migratus) - A general migration framework
+* [Ragtime](https://github.com/weavejester/ragtime) - Database-independent migration library
+
+## Email Sending
+
+* [Mailer](https://github.com/clojurewerkz/mailer) - An ActionMailer-inspired mailer library
+* [Postal](https://github.com/drewr/postal) - Clojure email support
+* [clj-mail](https://github.com/MayDaniel/clj-mail) - Send and receive emails from Clojure
+
+## Template Languages
+
+* [Basil](https://github.com/kumarshantanu/basil) - A general purpose template library
+* [Clostache](https://github.com/fhd/clostache) - {{ mustache }} for Clojure
+* [Enlive](https://github.com/cgrand/enlive) - A selector-based (à la CSS) templating and transformation system
+* [Fleet](https://github.com/Flamefork/fleet) - Templating System for Clojure
+* [Laser](https://github.com/Raynes/laser) - HTML transformation/templating
+* [Stencil](https://github.com/davidsantiago/stencil) - A fast, compliant implementation of Mustache
+* [Tinsel](https://github.com/davidsantiago/tinsel) - Selector-based templates with Hiccup
+
+
+It's just few categories, more libraries related to web development
+ for testing, data validation, text search, random data generation,
+ JSON parsing, exception handling, SQL abstractions and other you can find on
+[The Clojure Toolbox](http://www.clojure-toolbox.com/),
+[ClojureSphere](http://www.clojuresphere.com/) and
+[ClojureWerkz](http://clojurewerkz.org/) websites.


### PR DESCRIPTION
I've added simple page with list of libraries which can be useful for web development with Luminus to privide people who are new to Clojure web stack ideas what they can use for templating, database access, authentication and other aspects of webdev. Based on clojure-toolbox.com with minor additions. Basically it's just an idea, list can be expanded and improved in future.
Any suggestions about content and naming are welcome.
