### PR TITLE
Update deployment.md

### DIFF
--- a/resources/md/deployment.md
+++ b/resources/md/deployment.md
@@ -286,7 +286,7 @@ heroku create
 
 optionally, create a database for the application
 ```
-heroku addons:add heroku-postgresql
+heroku addons:create heroku-postgresql
 ```
 
 The connection settings can be found at your


### PR DESCRIPTION
`addons:add` still works at the moment, but it prints the deprecation warning.

"Previously to add an add-on you could use the command addons:add. That command is now deprecated in favor of the create command."