### PR TITLE
Add mention of deployment guide in Linode docs

### DIFF
--- a/resources/md/deployment.md
+++ b/resources/md/deployment.md
@@ -23,6 +23,7 @@ java -jar myapp.jar
 ## Deploying on Immutant App Server
 
 Please follow the steps outlined in the [official Immutant documentation](http://immutant.org/documentation/2.0.2/apidoc/guide-installation.html) for Immutant application server deployment.
+Also, [Linode](http://linode.com) has a guide on [how to deploy Luminus application with Immutant and WildFly on Ubuntu 14.04](https://linode.com/docs/applications/development/clojure-deployment-with-immutant-and-wildfly-on-ubuntu-14-04)
 
 ## Deploying to Tomcat
 


### PR DESCRIPTION
Hi,
I've written a Clojure app deployment guide for Linode docs, and I think it would be useful for Luminus users to have it mentioned here.