### PR TITLE
Remove hiccup from templating docs

### DIFF
--- a/resources/docs-1.x/html_templating.md
+++ b/resources/docs-1.x/html_templating.md
@@ -1,16 +1,13 @@
 ## Templating Options
 
-Luminus comes with the [Hiccup](https://github.com/weavejester/hiccup) dependency. If you're familiar with Hiccup then
-you can start using it out of the box.
+Luminus packages [Selmer](https://github.com/yogthos/Selmer) for more traditional style templating using plain text files as templates. 
 
-Hiccup uses standard Clojure data structures to represent its templates. On top of that, Hiccup provides a rich API of 
-helper functions for generating common HTML elements.
+Alternatively, you can choose to use a different templating
+engine altogether. A couple of popular options are:
 
-Luminus also packages [Selmer](https://github.com/yogthos/Selmer) for more traditional style templating using plain text files
-as templates. 
-
-You can choose to use either templating engine or combine them. Alternatively, you can choose to use a different templating
-engine altogether. A couple of popular options are [Enlive](https://github.com/cgrand/enlive) and [Stencil](https://github.com/davidsantiago/stencil).
+- [Hiccup](https://github.com/weavejester/hiccup)
+- [Enlive](https://github.com/cgrand/enlive)
+- [Stencil](https://github.com/davidsantiago/stencil).
 
 ## HTML Templating Using Selmer
 
@@ -608,85 +605,6 @@ When the `base.html` is rendered it will replace the `register` and `home` inclu
 from the templates they are referencing.
 
 For more details please see the [official documentation](https://github.com/yogthos/Selmer).
-
-## HTML Templating Using Hiccup
-
-[Hiccup](https://github.com/weavejester/hiccup) is a popular HTML templating engine for Clojure.
-The advantage of using Hiccup is that we can use the full power of Clojure to generate and manipulate our markup.
-This means that you don't have to learn a separate DSL for generating your HTML with its own rules and quirks.
-
-In Hiccup, HTML elements are represented by Clojure vectors and the structure of the element looks as following:
-
-```clojure
-[:tag-name {:attribute-key "attribute value"} tag-body]
-```
-
-For example, if we wanted to create a div with a paragraph in it, we could write:
-
-```clojure
-[:div {:id "hello", :class "content"} [:p "Hello world!"]]
-```
-
-which corresponds to the following HTML:
-
-```xml
-<div id="hello" class="content"><p>Hello world!</p></div>
-```
-
-Hiccup provides shortcuts for setting the id and class of the element, so instead of what we wrote above we could simply write:
-
-```clojure
-[:div#hello.content [:p "Hello world!"]]
-```
-
-Hiccup also provides a number of helper functions for defining common elements such as forms, links, images, etc. All of these functions simply output vectors in the format described above. This means that if a function doesn't do what you need, you can either write out the literal form for the element by hand or take its output and modify it to fit your needs. Each function which describes an HTML element can also take optional map of attributes as its first parameter:
-
-```clojure
-(image {:align "left"} "foo.png")
-```
-
-This would result in the following HTML:
-
-```xml
-<img align=\"left\" src=\"foo.png\">
-```
-
-However, it is best practice to use CSS for the actual styling of the elements in order to keep the structure separate from the representation.
-
-### Forms and Input
-
-Hiccup also provides helpers for creating HTML forms, here's an example:
-
-```clojure
-(form-to [:post "/login"]
-  (text-field {:placeholder "screen name"} "id")
-  (password-field {:placeholder "password"} "pass")
-  (submit-button "login"))
-```
-
-The helper takes a vector with the type of the HTTP request specified as a keyword followed by the URL string, the rest of the arguments should be HTML elements.
-The above will generate the following HTML:
-
-```xml
-<form action="/login" method="POST">
-  <input id="id" name="id" placeholder="screen name" type="text" />
-  <input id="pass" name="pass" placeholder="password" type="password" />
-  <input type="submit" value="login" />
-</form>
-```
-
-Finally, Luminus template provides a helper function under the `<yourapp>.util` namespace called `md->html`,
-this function will read a markdown file relative to `resources/public/` folder and return an HTML string. This can
-be used in conjunction with Hiccup functions, eg:
-
-```clojure
-(:require [<yourapp>.util :as util])
-...
-(html [:div.contenr [:p (util/md->html "/md/paragraph.md")]])
-```
-
-The markdown generation is done by markdown-clj, please see the [Github page](https://github.com/yogthos/markdown-clj) for
-details on supported syntax.
 
 ## Content caching
 


### PR DESCRIPTION
Since Hiccup is no longer bundled as a dependency, there is no longer a need to explain it in the docs.

Any feedback welcome!