### PR TITLE
Fix argument order in SQL function call with conn

### DIFF
--- a/resources/md/database.md
+++ b/resources/md/database.md
@@ -211,12 +211,12 @@ It can also be passed in an explicit connection, as would be the case for runnin
   "jdbc:postgresql://localhost/myapp_test?user=test&password=test")
   
 (create-user!
+  some-other-conn
   {:id "user1"
    :first_name "Bob"
    :last_name "Bobberton"
    :email "bob.bobberton@mail.com"
-   :pass "verysecret"}
-   some-other-conn)
+   :pass "verysecret"})
 ```
 
 The `conman` library also provides a `with-transaction` macro for running statements within a transaction.


### PR DESCRIPTION
On the "Database Access" page, there is an conman SQL function call which passes query arguments first, a connection second. In the current conman version, the arguments have to be switched around.