### PR TITLE
Added instructions to parse JNDI configurations

### DIFF
--- a/resources/docs-1.x/deployment.md
+++ b/resources/docs-1.x/deployment.md
@@ -46,6 +46,30 @@ cp target/myapp.war ~/tomcat/webapps/
 Your app will now be avaliable at the context `/myapp` when Tomcat starts. To deploy the app
 at root context, simply copy it to `webapp` as `ROOT.war`.
 
+### JNDI database configuration
+
+Tomcat may have database configuration specified as a [JNDI resource](https://tomcat.apache.org/tomcat-7.0-doc/jndi-resources-howto.html) (check JDBC Data Sources
+section). In this case you need to fetch this data from the Tomcat configuration and not from clojure profiles. Just change this lines in `src/clj/<app>/db/core.clj`:
+
+```clojure
+(defstate ^:dynamic *db*
+           :start (conman/connect!
+                   {:init-size  1
+                    :min-idle   1
+                    :max-idle   4
+                    :max-active 32
+                    :jdbc-url   (env :database-url)})
+           :stop (conman/disconnect! *db*))
+```
+
+to:
+
+```clojure
+(def ^:dynamic *db* {:name "java:comp/env/jdbc/EmployeeDB"})
+```
+
+(in this example `jdbc/EmployeeDB` is the same name as specified in `context.xml` and `web.xml` in the [JNDI HowTo page](https://tomcat.apache.org/tomcat-7.0-doc/jndi-resources-howto.html). Note that this name is case sensitive.)
+
 ## VPS Deployment
 
 Virtual Private Servers (VPS) such as [DigitalOcean](https://www.digitalocean.com/) provide a cheap hosting option for Clojure applications. 


### PR DESCRIPTION
Added instructions to parse JNDI configuration. I put this under deployment / Tomcat because the issue will probably arise during a deploy to Tomcat and will probably not arise in other conditions, but this instructions could also be moved into the DB sections.