### PR TITLE
Update ring-gzip-middleware

### DIFF
--- a/resources/md/middleware.md
+++ b/resources/md/middleware.md
@@ -68,5 +68,5 @@ handler <- wrap-formats <- wrap-defaults <- request
 
 * [ring-ratelimit](https://github.com/myfreeweb/ring-ratelimit) - Rate limiting middleware
 * [ring-etag-middleware](https://github.com/mikejs/ring-etag-middleware) - Calculates etags for ring responses and returns 304 responses when appropriate
-* [ring-gzip-middleware](https://github.com/mikejs/ring-gzip-middleware) - Gzips ring responses for user agents which can handle it
+* [ring-gzip-middleware](https://github.com/amalloy/ring-gzip-middleware) - Gzips ring responses for user agents which can handle it
 * [ring-upload-progress](https://github.com/joodie/ring-upload-progress) - Provide upload progress data in ring session


### PR DESCRIPTION
The aforementioned gzip middleware wasn't updated in 6 years. The one I'm including hasn't been in 3 years, either, but:
 * It is linked from the official [Ring Wiki](https://github.com/ring-clojure/ring/wiki/Third-Party-Libraries)
 * It works like a charm

I did try the older one first in my application, but the app would crash when deployed to Heroku. The new one works nicely, compresses fast and speeds my app up a lot.