### PR TITLE
Trigger case massaging on :one and :many.

### DIFF
--- a/resources/md/database.md
+++ b/resources/md/database.md
@@ -245,8 +245,14 @@ library:
 
 (defmethod hugsql.core/hugsql-result-fn :1 [sym]
   'yuggoth.db.core/result-one-snake->kebab)
+  
+(defmethod hugsql.core/hugsql-result-fn :one [sym]
+  'yuggoth.db.core/result-one-snake->kebab)
 
 (defmethod hugsql.core/hugsql-result-fn :* [sym]
+  'yuggoth.db.core/result-many-snake->kebab)
+  
+(defmethod hugsql.core/hugsql-result-fn :many [sym]
   'yuggoth.db.core/result-many-snake->kebab)
 ```
 


### PR DESCRIPTION
Not just :1 and :*. This makes it consistent no matter what syntax you use in your sql file. Not having this produced very unexpected results.