### PR TITLE
Create timestamp with 7 digits of sub-second precision

### DIFF
--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -492,7 +492,7 @@ CREATE TABLE guestbook
 (id INTEGER PRIMARY KEY AUTO_INCREMENT,
  name VARCHAR(30),
  message VARCHAR(200),
- timestamp TIMESTAMP);
+ timestamp TIMESTAMP(7));
 ```
 
 The guestbook table will store all the fields describing the message, such as the name of the


### PR DESCRIPTION
A proposal for issue #242 

On Windows, java.time.LocalDateTime/now has 0.1-microsecond precision.  This PR updates the documentation to guide readers to create a timestamp column with enough digits for that.

With this change, my guestbook passes tests on Windows (with `lein test`).  I have not tested the change on Macos or Unixes.
