### PR TITLE
Remove default Immutant References

### DIFF
--- a/resources/docs-1.x/deployment.md
+++ b/resources/docs-1.x/deployment.md
@@ -21,7 +21,7 @@ java -jar target/myapp.jar
 ```
 ## Deploying on Immutant
 
-A Luminus app created using lein new luminus myapp should deploy to [Immutant](http://immutant.org/) out of the box. 
+A Luminus app created using `lein new luminus myapp +immutant` should deploy to [Immutant](http://immutant.org/). 
 Simply run the following from the root folder of the applicaiton:
 
 ```

--- a/resources/md/deployment.md
+++ b/resources/md/deployment.md
@@ -12,8 +12,8 @@ The resulting `jar` can be found in the `target/uberjar` folder. It can be run a
 java -jar <app>.jar
 ```
 
-By default the standalone application uses an embedded Immutant server to run the application.
-However, if you used a profile such as `+jetty` then the alternate server will be used instead.
+By default the standalone application uses an embedded Jetty server to run the application.
+However, if you used a profile such as `+immutant` then the alternate server will be used instead.
 To specify a custom port you need to set the `$PORT` environment variable, eg:
 
 ```
@@ -327,7 +327,7 @@ openssl pkcs12 -export -in fullchain.pem -inkey privkey.pem -out pkcs.p12 -name 
 keytool -importkeystore -deststorepass <PASSWORD_STORE> -destkeypass <PASSWORD_KEYPASS> -destkeystore keystore.jks -srckeystore pkcs.p12 -srcstoretype PKCS12 -srcstorepass <STORE_PASS> -alias <NAME>
 ```
 
-If you're using Immutant as your HTTP server (Luminus default), then you have to update your `<app>.core` namespace as follows:
+If you're using Immutant as your HTTP server (`+immutant`), then you have to update your `<app>.core` namespace as follows:
 
 ```clojure
 (ns <app>.core

--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -78,7 +78,7 @@ initialize your application:
 
 <div class="lein">
 ```
-lein new luminus guestbook +h2
+lein new luminus guestbook +h2 +immutant
 cd guestbook
 ```
 </div>

--- a/resources/md/profiles.md
+++ b/resources/md/profiles.md
@@ -10,11 +10,11 @@ profile hints for the extended functionality.
 
 ### web servers
 
-Luminus defaults to using the [Immutant](http://immutant.org/) webserver, the following
+Luminus defaults to using the [Jetty](https://github.com/mpenet/jet) webserver, the following
 alternative servers are supported:
 
 * +aleph - adds [Aleph](https://github.com/ztellman/aleph) server support to the project
-* +jetty - adds [Jetty](https://github.com/mpenet/jet) support to the project
+* +immutant - add [Immutant](http://immutant.org/) support to the project
 * +http-kit - adds the [HTTP Kit](http://www.http-kit.org/) web server to the project
 
 ### databases

--- a/resources/md/servers.md
+++ b/resources/md/servers.md
@@ -8,8 +8,9 @@ While such middleware is useful in most situations, it will also incur a perform
 would not need to wrap it with the webjars middleware.
 
 ### Immutant Configuration
+Luminus used to using [Immutant](http://immutant.org/) as the default server, but now it defaults to Jetty.  The following information is still applicable to using `+immutant`.
 
-Luminus defaults to using [Immutant](http://immutant.org/) as the default server. This server provides a number of options that are unique to it.
+The [Immutant](http://immutant.org/) server provides a number of options that are unique to it.
 
 Immutant allows setting the number of worker and IO threads using the `:worker-threads` and the `:io-threads` keys respectively. For example, we could update the default configuration as follows:
 

--- a/resources/md/websockets.md
+++ b/resources/md/websockets.md
@@ -1,9 +1,9 @@
 This section will cover an example of using websockets for client/server communication with Immutant and HTTP Kit servers in Luminus. As the first step, create a new application. Our example uses Reagent components, so we'll include the `+cljs` profile.
 
-To create an Immutant based application use the default profile:
+To create an Immutant based application use the `+immutant` profile:
 
 ```
-lein new luminus multi-client-ws +cljs
+lein new luminus multi-client-ws +cljs +immutant
 ```
 
 To create an HTTP Kit based application use the `+http-kit` profile instead:


### PR DESCRIPTION
Since template version 3.37, Jetty has been the default webserver, but the documentation hasn't matched.  

Though more changes are necessary to update several of the documentation to match this, since `+immutant` is still a viable option, I've removed the references I could find to `immutant` being the default and replaced them with Jetty.  