### PR TITLE
use the officially supported JAVA_TOOL_OPTIONS env var

### DIFF
--- a/resources/md/deployment.md
+++ b/resources/md/deployment.md
@@ -193,7 +193,7 @@ Note that by default JVM is fairly aggressive about memory usage. If you'd like 
 ```
 [Service]
 ...
-_JAVA_OPTIONS="-Xmx256m"
+Environment=JAVA_TOOL_OPTIONS="-Xmx256m"
 ExecStart=/usr/bin/java -jar /var/myapp/myapp.jar
 ```
 


### PR DESCRIPTION
instead of _JAVA_OPTIONS, though both seem to work, even on OpenJDK 14.
See https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars002.html.
Also add "Environment=" directive before it, so peeps copy/paste valid unit config.