### PR TITLE
Add doc title to html header title

### DIFF
--- a/resources/templates/base.html
+++ b/resources/templates/base.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="keywords" content="luminus, clojure, framework, leiningen">
     <meta name="canonical" content="http://luminusweb.net">
-    <title>Luminus - a Clojure web framework</title>
+    <title>{% block header-title %}Luminus - a Clojure web framework{% endblock %}</title>
     <link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/color-brewer.min.css">
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon">

--- a/resources/templates/contribute.html
+++ b/resources/templates/contribute.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block header-title %}How you can help | {{block.super}}{% endblock %}
 {% block content %}
 <div class="column column-75">
   <div class="column-wrapper">

--- a/resources/templates/docs.html
+++ b/resources/templates/docs.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block header-title %}{{title}} | {{block.super}}{% endblock %}
 {% block content %}
 <div class="row">
   <div class="column column-75">


### PR DESCRIPTION
Set the html header title to unique titles based on the doc title, so we can identify what page we're on.

Currently, we can't distinguish which page of the site we're on when looking at the browser tabs:

<img width="425" alt="Screen Shot 2020-08-17 at 12 53 20 PM" src="https://user-images.githubusercontent.com/286057/90430254-1f69d580-e095-11ea-8942-a99c72f10f52.png">

After this change:

<img width="427" alt="Screen Shot 2020-08-17 at 12 53 35 PM" src="https://user-images.githubusercontent.com/286057/90430267-25f84d00-e095-11ea-8fe1-defc83779317.png">
