### PR TITLE
Wrong path and namespace in section "Adding some tests"

### DIFF
--- a/resources/md/guestbook.md
+++ b/resources/md/guestbook.md
@@ -894,10 +894,10 @@ We can test that everything is working as expected by adding a comment in our co
 ## Adding some tests
 
 Now that we have our application working we can add some tests for it.
-Let's open up the `test/clj/guestbook/test/db/core.clj` namespace and update it as follows:
+Let's open up the `test/clj/guestbook/db/core_test.clj` namespace and update it as follows:
 
 ```clojure
-(ns guestbook.test.db.core
+(ns guestbook.db.core-test
   (:require
    [guestbook.db.core :refer [*db*] :as db]
    [java-time.pre-java8]


### PR DESCRIPTION
Tested with a project generated with `lein new luminus guestbook +h2 +immutant`

* Tutorial shows the file should be `test/clj/guestbook/test/db/core.clj` but it is `test/clj/guestbook/db/core_test.clj`
* Tutorial uses the namespace `guestbook.test.db.core` for the tests but it should be `guestbook.db.core-test`