### PR TITLE
Add HTTP requests logging example to documentation

### DIFF
--- a/resources/md/logging.md
+++ b/resources/md/logging.md
@@ -103,3 +103,36 @@ java -Dlogback.configurationFile=prod-log-config.xml -jar myapp.jar
 ```
 
 Please refer to the [official documentation](http://logback.qos.ch/manual/configuration.html) for further information on configuring `logback`.
+
+
+### Logging HTTP requests
+
+You can use [ring-logger](https://github.com/nberger/ring-logger#usage) in order to log HTTP requests:
+
+
+```clojure
+# project.clj
+
+  :dependencies [...
+                 [ring-logger "1.1.1"]
+                ]
+
+```
+
+```clojure
+(ns myapp.routes.home
+  (:require
+   ...
+   [ring.logger]))
+
+
+(defn home-routes []
+  [ "" 
+   {:middleware [
+                 ring.logger/wrap-with-logger
+                 middleware/wrap-csrf
+                 middleware/wrap-formats
+                 ]}
+   ["/" {:get home-page}]
+   ["/about" {:get about-page}]])
+  ...


### PR DESCRIPTION
Adds HTTP requests logging example to documentation

Sample output:
```
2023-09-02 22:53:13,026 [XNIO-1 task-3] INFO  ring.logger - {:request-method :get, :uri "/", :server-name "localhost", :ring.logger/type :starting} 
2023-09-02 22:53:13,027 [XNIO-1 task-3] DEBUG ring.logger - {:request-method :get, :uri "/", :server-name "localhost", :ring.logger/type :params, :params {}} 
2023-09-02 22:53:13,062 [XNIO-1 task-3] INFO  ring.logger - {:request-method :get, :uri "/", :server-name "localhost", :ring.logger/type :finish, :status 200, :ring.logger/ms 37} 

```